### PR TITLE
docs: add missing community contact email

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ A good bug report shouldn't leave others needing to chase you up for more inform
 <!-- omit in toc -->
 #### How Do I Submit a Good Bug Report?
 
-> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to .
+> You must never report security related issues, vulnerabilities or bugs including sensitive information to the issue tracker, or elsewhere in public. Instead sensitive bugs must be sent by email to <sanidhyyy@gmail.com>.
 <!-- You may add a PGP key to allow the messages to be sent encrypted as well. -->
 
 We use GitHub issues to track bugs and errors. If you run into an issue with the project:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,20 +2,12 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
-| Version | Supported          |
-| ------- | ------------------ |
-| 5.1.x   | :white_check_mark: |
-| 5.0.x   | :x:                |
-| 4.0.x   | :white_check_mark: |
-| < 4.0   | :x:                |
+This project is maintained on the default branch. Please use the latest commit when reporting issues.
 
 ## Reporting a Vulnerability
 
-Use this section to tell people how to report a vulnerability.
+Report security vulnerabilities privately to <sanidhyyy@gmail.com>.
+Please do not open a public GitHub issue for security reports.
 
-Tell them where to go, how often they can expect to get an update on a
-reported vulnerability, what to expect if the vulnerability is accepted or
-declined, etc.
+Reports will be reviewed as soon as possible. If a report is accepted, we will work on a fix.
+If it is declined, we will explain why.


### PR DESCRIPTION
## Summary
- fill empty community contact placeholders with sanidhyyy@gmail.com

## Changes
- `CONTRIBUTING.md`: sent by email to . -> sent by email to <sanidhyyy@gmail.com>.
- `SECURITY.md`: replace GitHub SECURITY template with report address sanidhyyy@gmail.com
